### PR TITLE
Same as previous pull request

### DIFF
--- a/keymaps/cut-line.cson
+++ b/keymaps/cut-line.cson
@@ -10,7 +10,8 @@
 '.pane.active .editor':
   'cmd-x': 'cut-line:cut-line'
   'cmd-c': 'cut-line:copy-line'
-
+  'cmd-v': 'cut-line:paste-line'
+  
 # Active panel
 # .pane.active > .item-views > .editor > .scroll-view > .overlayer
 

--- a/keymaps/cut-line.cson
+++ b/keymaps/cut-line.cson
@@ -7,11 +7,10 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.pane.active .editor':
+'.pane.active > .item-views > .editor':
   'cmd-x': 'cut-line:cut-line'
   'cmd-c': 'cut-line:copy-line'
   'cmd-v': 'cut-line:paste-line'
-  
 # Active panel
 # .pane.active > .item-views > .editor > .scroll-view > .overlayer
 

--- a/lib/cut-line.coffee
+++ b/lib/cut-line.coffee
@@ -34,8 +34,11 @@ module.exports =
         return elm != ""
       selections = @editor.getSelectionsOrderedByBufferPosition()
       if selections.length == 1
-        for line in clipLines
-          selections[0].insertText(line+"\n")
+        for line, i in clipLines
+          if i < clipLines.length-1
+            selections[0].insertText(line+"\n")
+          else
+            selections[0].insertText(line)
       else
         for selection, i in selections
           selection.insertText(clipLines[i] || clipLines[i%clipLines.length])

--- a/lib/cut-line.coffee
+++ b/lib/cut-line.coffee
@@ -24,15 +24,16 @@ module.exports =
 
   pasteLine: ->
     clipContents = atom.clipboard.readWithMetadata();
-    if clipContents.metadata && clipContents.metadata.fullline
-      @editor.moveCursorToBeginningOfLine()
-      @editor.insertNewlineAbove()
-      cursors = @editor.getCursors()
+    activeEditor = atom.workspace.getActiveEditor();
+    if clipContents.metadata && clipContents.metadata.fullline && activeEditor
+      activeEditor.insertNewlineAbove()
+      activeEditor.moveCursorToBeginningOfLine()
+      cursors = activeEditor.getCursors()
       cursors = cursors.sort (a,b) -> return if a.getBufferRow() > b.getBufferRow() then 1 else -1
       clipLines = clipContents.text.split("\n")
       clipLines = clipLines.filter (elm) ->
         return elm != ""
-      selections = @editor.getSelectionsOrderedByBufferPosition()
+      selections = activeEditor.getSelectionsOrderedByBufferPosition()
       if selections.length == 1
         for line, i in clipLines
           if i < clipLines.length-1
@@ -42,8 +43,6 @@ module.exports =
       else
         for selection, i in selections
           selection.insertText(clipLines[i] || clipLines[i%clipLines.length])
-    else
-      @editor.pasteText();
 
   selectLine: ->
     @prevPos = null

--- a/lib/cut-line.coffee
+++ b/lib/cut-line.coffee
@@ -2,18 +2,45 @@ module.exports =
   activate: ->
     atom.workspaceView.command "cut-line:cut-line", => @cutLine()
     atom.workspaceView.command "cut-line:copy-line", => @copyLine()
+    atom.workspaceView.command "cut-line:paste-line", => @pasteLine()
 
   cutLine: ->
-    @selectLine()
+    fullline = @selectLine()
     @editor.cutSelectedText()
+    if fullline
+      atom.clipboard.metadata = atom.clipboard.metadata || {}
+      atom.clipboard.metadata.fullline = true
 
   copyLine: ->
-    @selectLine()
+    fullline = @selectLine()
     @editor.copySelectedText()
+    if fullline
+      atom.clipboard.metadata = atom.clipboard.metadata || {}
+      atom.clipboard.metadata.fullline = true
     if @prevPos
       for cursor in @prevPos
         cursor[0].clearSelection()
         cursor[0].setBufferPosition(cursor[1])
+
+  pasteLine: ->
+    clipContents = atom.clipboard.readWithMetadata();
+    if clipContents.metadata && clipContents.metadata.fullline
+      @editor.moveCursorToBeginningOfLine()
+      @editor.insertNewlineAbove()
+      cursors = @editor.getCursors()
+      cursors = cursors.sort (a,b) -> return if a.getBufferRow() > b.getBufferRow() then 1 else -1
+      clipLines = clipContents.text.split("\n")
+      clipLines = clipLines.filter (elm) ->
+        return elm != ""
+      selections = @editor.getSelectionsOrderedByBufferPosition()
+      if selections.length == 1
+        for line in clipLines
+          selections[0].insertText(line+"\n")
+      else
+        for selection, i in selections
+          selection.insertText(clipLines[i] || clipLines[i%clipLines.length])
+    else
+      @editor.pasteText();
 
   selectLine: ->
     @prevPos = null
@@ -22,6 +49,8 @@ module.exports =
     if @selectionsAreEmpty()
       @prevPos = ([cursor, cursor.getBufferPosition()] for cursor in cursors)
       @editor.selectLine()
+      @editor.selections = @editor.getSelectionsOrderedByBufferPosition()
+      return true;
 
   selectionsAreEmpty: ->
     for selection in @editor.getSelections()

--- a/menus/cut-line.cson
+++ b/menus/cut-line.cson
@@ -13,7 +13,7 @@
       'submenu': [
         { 'label': 'Copy line', 'command': 'cut-line:copy-line' }
         { 'label': 'Cut line', 'command': 'cut-line:cut-line' }
-        { 'label': 'Paste line', 'command': 'cut-line:paste-line' }
+        { 'label': 'Paste line', 'command': 'cut-line:paste-line' }        
       ]
     ]
   }

--- a/menus/cut-line.cson
+++ b/menus/cut-line.cson
@@ -3,6 +3,7 @@
   '.overlayer':
       'Copy line': 'cut-line:copy-line'
       'Cut line': 'cut-line:cut-line'
+      'Paste line': 'cut-line:paste-line'
 
 'menu': [
   {
@@ -12,6 +13,7 @@
       'submenu': [
         { 'label': 'Copy line', 'command': 'cut-line:copy-line' }
         { 'label': 'Cut line', 'command': 'cut-line:cut-line' }
+        { 'label': 'Paste line', 'command': 'cut-line:paste-line' }
       ]
     ]
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cut-line",
   "main": "./lib/cut-line",
-  "version": "0.4.1",
+  "version": "0.4.0",
   "private": true,
   "description": "Overrides Cmd-X and Cmd-C with no selection to cut (or copy) the entire line.",
   "activationEvents": [
@@ -9,10 +9,24 @@
     "cut-line:copy-line",
     "cut-line:paste-line"
   ],
-  "repository": "https://github.com/tekkub/cut-line",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tekkub/cut-line"
+  },
   "license": "None",
   "engines": {
     "atom": ">0.50.0"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "readme": "# cut-line package\n\nOverride the default cut action (cmd-x) when no text is selected.  Instead of cutting the char after the cursor, the entire line is cut.\n",
+  "readmeFilename": "README.md",
+  "bugs": {
+    "url": "https://github.com/tekkub/cut-line/issues"
+  },
+  "homepage": "https://github.com/tekkub/cut-line",
+  "_id": "cut-line@0.4.0",
+  "dist": {
+    "shasum": "4d653a309d2cd0edd2f009aca62b973a58f11f54"
+  },
+  "_from": "/Users/djak250/.atom/.node-gyp/.atom/.apm/cut-line/0.4.0/package.tgz"
 }

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "cut-line",
   "main": "./lib/cut-line",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "description": "Overrides Cmd-X and Cmd-C with no selection to cut (or copy) the entire line.",
   "activationEvents": [
     "cut-line:cut-line",
-    "cut-line:copy-line"
+    "cut-line:copy-line",
+    "cut-line:paste-line"
   ],
   "repository": "https://github.com/tekkub/cut-line",
   "license": "None",


### PR DESCRIPTION
This is more stable and has some of the kinks ironed out. I updated your cut-line.cson to be more specific because atom considers the text boxes on the settings page to be editors and so cutline was causing the default cut,copy, and paste to fail on there.
