### PR TITLE
updating to new atom selector api

### DIFF
--- a/keymaps/cut-line.cson
+++ b/keymaps/cut-line.cson
@@ -1,14 +1,14 @@
-'.platform-darwin .pane.active > .item-views > .editor':
+'.platform-darwin atom-pane.active > .item-views > atom-text-editor':
   'cmd-x': 'cut-line:cut-line'
   'cmd-c': 'cut-line:copy-line'
   'cmd-v': 'cut-line:paste-line'
 
-'.platform-linux .pane.active > .item-views > .editor':
+'.platform-linux atom-pane.active > .item-views > atom-text-editor':
   'ctrl-c': 'cut-line:copy-line'
   'ctrl-x': 'cut-line:cut-line'
   'ctrl-v': 'cut-line:paste-line'
 
-'.platform-win32 .pane.active > .item-views > .editor':
+'.platform-win32 atom-pane.active > .item-views > atom-text-editor':
   'ctrl-c': 'cut-line:copy-line'
   'ctrl-x': 'cut-line:cut-line'
   'ctrl-v': 'cut-line:paste-line'


### PR DESCRIPTION
cut-line
keymaps/cut-line.cson
Use the `atom-pane` tag instead of the `pane` class.
Use the `atom-text-editor` tag instead of the `editor` class.
