### PR TITLE
Atom.Object.defineProperty.get is deprecated.

### DIFF
--- a/lib/cut-line.coffee
+++ b/lib/cut-line.coffee
@@ -1,8 +1,8 @@
 module.exports =
   activate: ->
-    atom.workspaceView.command "cut-line:cut-line", => @cutLine()
-    atom.workspaceView.command "cut-line:copy-line", => @copyLine()
-    atom.workspaceView.command "cut-line:paste-line", => @pasteLine()
+    atom.views.getView(atom.workspace).command "cut-line:cut-line", => @cutLine()
+    atom.views.getView(atom.workspace).command "cut-line:copy-line", => @copyLine()
+    atom.views.getView(atom.workspace).command "cut-line:paste-line", => @pasteLine()
 
   cutLine: ->
     fullline = @selectLine()


### PR DESCRIPTION
atom.workspaceView is no longer available.
In most cases you will not need the view. See the Workspace docs for
alternatives: https://atom.io/docs/api/latest/Workspace.
If you do need the view, please use `atom.views.getView(atom.workspace)`,
which returns an HTMLElement.

```
Atom.Object.defineProperty.get (/opt/homebrew-cask/Caskroom/atom/latest/Atom.app/Contents/Resources/app/src/atom.js:55:11)
Object.activate (/Users/tcarlsen/.dotfiles/atom.symlink/packages/cut-line/lib/cut-line.coffee:5:9)
```

fixes #18
